### PR TITLE
Windows Solution Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ CMakeLists.txt.user
 /.vscode/
 # Ignore IntelliJ's build dir
 cmake-build-*/
+# Ignore lua until it can be included
+/Externals/lua/

--- a/Source/Core/Core/Core.vcxproj
+++ b/Source/Core/Core/Core.vcxproj
@@ -365,10 +365,16 @@
     <ClCompile Include="PowerPC\PPCCache.cpp" />
     <ClCompile Include="PowerPC\PPCSymbolDB.cpp" />
     <ClCompile Include="PowerPC\PPCTables.cpp" />
+    <ClCompile Include="PowerPC\ScriptHooks.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="PowerPC\SignatureDB\CSVSignatureDB.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\DSYSignatureDB.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\MEGASignatureDB.cpp" />
     <ClCompile Include="PowerPC\SignatureDB\SignatureDB.cpp" />
+    <ClCompile Include="ScriptEngine.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="State.cpp" />
     <ClCompile Include="SysConf.cpp" />
     <ClCompile Include="TitleDatabase.cpp" />
@@ -662,6 +668,9 @@
     <ClInclude Include="PowerPC\JitCommon\JitAsmCommon.h" />
     <ClInclude Include="PowerPC\JitCommon\JitBase.h" />
     <ClInclude Include="PowerPC\JitCommon\JitCache.h" />
+    <ClInclude Include="PowerPC\ScriptHooks.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="PowerPC\SignatureDB\CSVSignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\DSYSignatureDB.h" />
     <ClInclude Include="PowerPC\SignatureDB\MEGASignatureDB.h" />
@@ -674,6 +683,9 @@
     <ClInclude Include="PowerPC\PPCSymbolDB.h" />
     <ClInclude Include="PowerPC\PPCTables.h" />
     <ClInclude Include="PowerPC\Profiler.h" />
+    <ClInclude Include="ScriptEngine.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="State.h" />
     <ClInclude Include="SyncIdentifier.h" />
     <ClInclude Include="SysConf.h" />

--- a/Source/Core/Core/Core.vcxproj.filters
+++ b/Source/Core/Core/Core.vcxproj.filters
@@ -185,6 +185,7 @@
     <ClCompile Include="NetPlayClient.cpp" />
     <ClCompile Include="NetPlayServer.cpp" />
     <ClCompile Include="PatchEngine.cpp" />
+    <ClCompile Include="ScriptEngine.cpp" />
     <ClCompile Include="State.cpp" />
     <ClCompile Include="SysConf.cpp" />
     <ClCompile Include="TitleDatabase.cpp" />
@@ -628,6 +629,9 @@
     <ClCompile Include="PowerPC\PPCTables.cpp">
       <Filter>PowerPC</Filter>
     </ClCompile>
+    <ClCompile Include="PowerPC\ScriptHooks.cpp">
+      <Filter>PowerPC</Filter>
+    </ClCompile>
     <ClCompile Include="PowerPC\JitCommon\JitAsmCommon.cpp">
       <Filter>PowerPC\JitCommon</Filter>
     </ClCompile>
@@ -1020,6 +1024,7 @@
     <ClInclude Include="NetPlayProto.h" />
     <ClInclude Include="NetPlayServer.h" />
     <ClInclude Include="PatchEngine.h" />
+    <ClInclude Include="ScriptEngine.h" />
     <ClInclude Include="State.h" />
     <ClInclude Include="SysConf.h" />
     <ClInclude Include="Titles.h" />
@@ -1432,6 +1437,9 @@
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\PPCTables.h">
+      <Filter>PowerPC</Filter>
+    </ClInclude>
+    <ClInclude Include="PowerPC\ScriptHooks.h">
       <Filter>PowerPC</Filter>
     </ClInclude>
     <ClInclude Include="PowerPC\Profiler.h">

--- a/Source/Core/Core/ScriptEngine.cpp
+++ b/Source/Core/Core/ScriptEngine.cpp
@@ -13,7 +13,11 @@
 #include <vector>
 
 #include <cassert>
-#include "lua.hpp"
+#ifdef _WIN32
+  #include <lua.hpp>
+#else
+  #include <lua5.3/lua.hpp>
+#endif
 
 #include "Common/Assert.h"
 #include "Common/IniFile.h"

--- a/Source/Core/Core/ScriptEngine.cpp
+++ b/Source/Core/Core/ScriptEngine.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 #include <cassert>
-#include <lua5.3/lua.hpp>
+#include "lua.hpp"
 
 #include "Common/Assert.h"
 #include "Common/IniFile.h"

--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -37,7 +37,9 @@
     <Link>
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;rpcrt4.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='x64'">opengl32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">lua53.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(ExternalsDir)ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">$(ExternalsDir)lua\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <Manifest>
       <AdditionalManifestFiles>DolphinQt.manifest;%(AdditionalManifestFiles)</AdditionalManifestFiles>
@@ -104,6 +106,9 @@
     <ClCompile Include="Config\NewPatchDialog.cpp" />
     <ClCompile Include="Config\PatchesWidget.cpp" />
     <ClCompile Include="Config\PropertiesDialog.cpp" />
+    <ClCompile Include="Config\ScriptsWidget.cpp">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="Config\SettingsWindow.cpp" />
     <ClCompile Include="Config\VerifyWidget.cpp" />
     <ClCompile Include="ConvertDialog.cpp" />
@@ -261,6 +266,9 @@
     <QtMoc Include="Config\Mapping\WiimoteEmuMotionControl.h" />
     <QtMoc Include="Config\Mapping\WiimoteEmuMotionControlIMU.h" />
     <QtMoc Include="Config\PropertiesDialog.h" />
+    <QtMoc Include="Config\ScriptsWidget.h">
+      <ExcludedFromBuild Condition="'$(Platform)'!='x64' OR '$(UseLuaScripts)'!='true'">true</ExcludedFromBuild>
+    </QtMoc>
     <QtMoc Include="Config\SettingsWindow.h" />
     <QtMoc Include="Config\VerifyWidget.h" />
     <QtMoc Include="ConvertDialog.h" />

--- a/Source/UnitTests/UnitTests.vcxproj
+++ b/Source/UnitTests/UnitTests.vcxproj
@@ -27,7 +27,9 @@
         -->
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;rpcrt4.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='x64'">opengl32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">lua53.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(ExternalsDir)ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">$(ExternalsDir)lua\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -7,6 +7,7 @@
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
     <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with /Brepro)-->
     <LinkIncremental>false</LinkIncremental>
+    <UseLuaScripts>true</UseLuaScripts>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->
@@ -34,6 +35,7 @@
       <AdditionalIncludeDirectories>$(ExternalsDir)liblzma\api;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)libpng;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)libusb\libusb;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">$(ExternalsDir)lua\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)LZO;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)miniupnpc\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(ExternalsDir)minizip;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -69,6 +71,7 @@
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">_ARCH_64=1;_M_X86=1;_M_X86_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='ARM64'">_ARCH_64=1;_M_ARM_64=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">HAVE_FFMPEG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='x64' AND '$(UseLuaScripts)'=='true'">USE_LUA_SCRIPTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!--
       Make sure we include a clean version of windows.h.
       -->
@@ -118,6 +121,8 @@
       4946  Reinterpret cast between related types
       -->
       <AdditionalOptions>/w44263 /w44265 /w44946 %(AdditionalOptions)</AdditionalOptions>
+      <!-- Suppress warning C4267 since it is treated as an error -->
+      <AdditionalOptions>/Wv:12 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions>/Brepro %(AdditionalOptions)</AdditionalOptions>
       <!--
         A (currently) hidden switch, like /Brepro, furthermore enabling warnings about non-deterministic code.

--- a/Source/VSProps/Base.props
+++ b/Source/VSProps/Base.props
@@ -7,7 +7,7 @@
     <TargetName Condition="'$(ConfigurationType)'=='Application'">$(ProjectName)$(TargetSuffix)</TargetName>
     <!--Set link /INCREMENTAL:NO to remove some entropy from builds (assists with /Brepro)-->
     <LinkIncremental>false</LinkIncremental>
-    <UseLuaScripts>true</UseLuaScripts>
+    <UseLuaScripts>false</UseLuaScripts>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <!--ClCompile Base-->

--- a/docs/Scripts.md
+++ b/docs/Scripts.md
@@ -5,14 +5,33 @@ Dolphin ships support for Lua 5.3 scripts that run embedded with the emulator.
 *Caution:* Never run untrusted scripts or scripts you do not understand yourself!
 Scripts will have access to your system like any other program, including the ability to do nasty things.
 
-**Requirements**
+## Requirements
+
+### Linux/OSX
 
 Script support is disabled by default, and has to be enabled via CMake flag `-DLUA_SCRIPTS=true`.
 
-Scripting support requires Lua sources while compiling and the Lua 5.3 dynamic library at runtime.
+It also requires Lua sources while compiling and the Lua 5.3 dynamic library at runtime.
 Debian provides both with the `liblua5.3-dev` and `lua5.3` packages.
 
-**Usage**
+### Windows
+
+Script support is disabled by default, and has to be enabled through a few different steps.
+
+First, script support requires the Windows library for Lua 5.3. Go to the [Lua Binaries page](http://luabinaries.sourceforge.net/)
+and select the latest release of 5.3. Select **Windows Libraries**, then select **Static**, and download the latest Win64 release
+(e.g. `lua-5.3.5_Win64_vc16_lib`).
+
+Unzip the Lua zip file to the `Externals` directory and rename it `lua`. Then create a new directory in the `lua` directory
+named `lib`. Move `lua53.lib` into the `lib` directory. Your `lua` folder should now have the following two files in the
+following directory structure:
+
+- Externals/lua/include/lua.hpp
+- Externals/lua/lib/lua53.lib
+
+Last, open `Source/VSProps/Base.props` and change the XML element `UseLuaScripts` to `true`.
+
+## Usage
 
 Scripts are defined in game properties and are run just before emulation starts.
 Any Lua code blocks emulator progression.


### PR DESCRIPTION
This pull request allows Lua scripting to be used for Windows builds using the solution file. I'm not really a Visual Studio guy, so I don't expect this to necessarily be the most correct way to accomplish this. Anybody who knows Visual Studio, please feel free to critique 😄 

Some notes:

- I added a new base property called `UseLuaScripts` which is used as a conditional for lua scripting related functionality.
- I also added instructions for how to get it running on Windows.
- I have to suppress error C4267 or [it will error](https://gist.github.com/NicholasMoser/15b27417e7012e8f5f607df0edfadafd#file-build-log-L1108).
- Currently Lua for Windows must be downloaded manually. I wonder if the Lua license would allow distributing it with Dolphin like ffmpeg?

Unrelated to the PR, but thank you very much for implementing this. I've already gotten a ton of use out of it for modding GameCube games!